### PR TITLE
Remap functions used vertexRemap incorrectly

### DIFF
--- a/cp/process.cpp
+++ b/cp/process.cpp
@@ -17,7 +17,6 @@ enum
 {
     FLAGS_NONE                  = 0x0,
     FLAGS_IGNORE_SLOWDOWN_AT    = 0x1,
-    FLAGS_IGNORE_SLOWDOWN_VF    = 0x2,
 };
 
 static const float g_Epsilon = 0.0001f;
@@ -46,11 +45,11 @@ static const TestMedia g_TestMedia[] =
     { FLAGS_NONE,               MEDIA_PATH L"SuperSimpleRunner._obj",   1.660000f, 1.f,        1.660000f, 1.f,        1.660000f, 1.f,        1.660000f, 1.f,        0,  0   },
     { FLAGS_NONE,               MEDIA_PATH L"shuttle._obj",             0.878247f, 1.745161f,  0.696429f, 1.383871f,  0.870130f, 1.285372f,  0.798701f, 1.179856f,  0,  107 },
     { FLAGS_NONE,               MEDIA_PATH L"player_ship_a._obj",       1.102867f, 1.053140f,  1.091062f, 1.041868f,  1.102867f, 1.053140f,  1.091062f, 1.041868f,  0,  0   },
-    { FLAGS_IGNORE_SLOWDOWN_VF, MEDIA_PATH L"FSEngineGeo._obj",         1.689465f, 1.013975f,  1.676662f, 1.006291f,  1.689465f, 1.013975f,  1.676662f, 1.006291f,  10, 0   },
+    { FLAGS_NONE,               MEDIA_PATH L"FSEngineGeo._obj",         1.689465f, 1.013975f,  1.676662f, 1.006291f,  1.689465f, 1.013975f,  1.676662f, 1.006291f,  10, 0   },
     { FLAGS_NONE,               MEDIA_PATH L"sphere.vbo",               1.001894f, 1.885918f,  0.630682f, 1.187166f,  1.001894f, 1.885918f,  0.630682f, 1.187166f,  0,  0   },
     { FLAGS_NONE,               MEDIA_PATH L"cylinder.vbo",             1.079365f, 1.046154f,  1.079365f, 1.046154f,  1.079365f, 1.046154f,  1.079365f, 1.046154f,  0,  0   },
     { FLAGS_NONE,               MEDIA_PATH L"torus.vbo",                1.000918f, 2.001837f,  0.642332f, 1.284665f,  1.000918f, 2.001837f,  0.642332f, 1.284665f,  0,  0   },
-    { FLAGS_IGNORE_SLOWDOWN_VF, MEDIA_PATH L"Head_Big_Ears.vbo",        0.815828f, 1.604267f,  0.664554f, 1.306799f,  0.815828f, 1.604267f,  0.664554f, 1.306799f,  0,  0   },
+    { FLAGS_NONE,               MEDIA_PATH L"Head_Big_Ears.vbo",        0.815828f, 1.604267f,  0.664554f, 1.306799f,  0.815828f, 1.604267f,  0.664554f, 1.306799f,  0,  0   },
 };
 
 namespace
@@ -896,14 +895,11 @@ bool Test03()
 
                         if (ratio > ratioOrig)
                         {
-                            if (!(g_TestMedia[index].options & FLAGS_IGNORE_SLOWDOWN_VF))
-                            {
-                                pass = false;
-                                success = false;
-                                printe("\nERROR: OptimizeVertices %u vcache, %u failed compared to original:\n%S\n", s_vcache[vindex], s_restart[vindex], szPath);
-                                print("\toriginal: vertex fetch ratio %f\n", ratioOrig);
-                                print("\toptimized: vertex fetch ratio %f\n", ratio);
-                            }
+                            pass = false;
+                            success = false;
+                            printe("\nERROR: OptimizeVertices %u vcache, %u failed compared to original:\n%S\n", s_vcache[vindex], s_restart[vindex], szPath);
+                            print("\toriginal: vertex fetch ratio %f\n", ratioOrig);
+                            print("\toptimized: vertex fetch ratio %f\n", ratio);
                         }
                     }
                 }
@@ -1274,14 +1270,11 @@ bool Test04()
 
                         if (ratio > ratioOrig)
                         {
-                            if (!(g_TestMedia[index].options & FLAGS_IGNORE_SLOWDOWN_VF))
-                            {
-                                pass = false;
-                                success = false;
-                                printe("ERROR: OptimizeVertices %u vcache, %u remap failed compared to original:\n%S\n", s_vcache[vindex], s_restart[vindex], szPath);
-                                print("\toriginal: vertex fetch ratio %f\n", ratioOrig);
-                                print("\toptimized: vertex fetch ratio %f\n", ratio);
-                            }
+                            pass = false;
+                            success = false;
+                            printe("ERROR: OptimizeVertices %u vcache, %u remap failed compared to original:\n%S\n", s_vcache[vindex], s_restart[vindex], szPath);
+                            print("\toriginal: vertex fetch ratio %f\n", ratioOrig);
+                            print("\toptimized: vertex fetch ratio %f\n", ratio);
                         }
                     }
                 }

--- a/mesh/adjacency.cpp
+++ b/mesh/adjacency.cpp
@@ -2378,7 +2378,7 @@ bool Test19()
                     success = false;
                     break;
                 }
-                if ( destvb[ j ] != remap[ srcvb[ j ] ] )
+                if ( srcvb[ j ] != remap[ destvb[ j ] ] )
                 {
                     printe("\nERROR: FinalizeVBAndPointReps cube identify vb failed\n" );
                     success = false;
@@ -2508,9 +2508,9 @@ bool Test19()
                                             22, 20, 21, 23 };
 
         static const uint32_t s_preps[] = { 0, 1, 2, 3, 4, 5,
-                                            6, 7, 3, 6, 2, 7,
-                                            4, 1, 5, 0, 1, 4,
-                                            3, 6, 5, 0, 7, 2 };
+                                            6, 7, 0, 5, 7, 2,
+                                            1, 4, 6, 3, 2, 6,
+                                            5, 1, 3, 7, 4, 0 };
 
         HRESULT hr = FinalizeVBAndPointReps( srcvb.get(), sizeof(uint32_t), 24, s_fmCubePointReps, nullptr, 0, s_remap, destvb.get(), prout.get() );
         if ( FAILED(hr) )
@@ -2592,15 +2592,17 @@ bool Test19()
                                             19, uint32_t(-1), 16, 18,
                                             22, 20, 21, 23 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 0, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 0,
-                                            19, 16, 21, 22, 20, 23 };
+        static const uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                            6, 4, 5, 7,
+                                            11, 9, 0, 10,
+                                            14, 12, 13, 15,
+                                            19, 0, 16, 18,
+                                            22, 20, 21, 23 };
 
         static const uint32_t s_preps[] = { 0, 1, 2, 3, 4, 5,
-                                            6, 7, uint32_t(-1), 6, 2, 7,
-                                            4, 1, 5, 0, 1, uint32_t(-1),
-                                            3, 6, 5, 0, 7, 2 };
+                                            6, 7, 0, 5, uint32_t(-1), 2,
+                                            1, 4, 6, 3, 2, uint32_t(-1),
+                                            5, 1, 3, 7, 4, 0 };
 
         HRESULT hr = FinalizeVBAndPointReps( srcvb.get(), sizeof(uint32_t), 24, s_fmCubePointReps, nullptr, 0, s_remap, destvb.get(), prout.get() );
         if ( FAILED(hr) )
@@ -2678,7 +2680,7 @@ bool Test20()
                     success = false;
                     break;
                 }
-                if ( destvb[ j ] != remap[ srcvb[ j ] ] )
+                if ( srcvb[ j ] != remap[ destvb[ j ] ] )
                 {
                     printe("\nERROR: FinalizeVBAndPointReps dups cube identify vb failed\n" );
                     success = false;
@@ -2694,7 +2696,7 @@ bool Test20()
                     success = false;
                     break;
                 }
-                if ( destvb[ j ] != remap[ srcvb[ i ] ] )
+                if ( srcvb[ i ] != remap[ destvb[ j ] ] )
                 {
                     printe("\nERROR: FinalizeVBAndPointReps dups cube identify vb failed (2)\n" );
                     success = false;
@@ -2728,17 +2730,19 @@ bool Test20()
                                             22, 20, 21, 23,
                                             27, 26, 25, 24 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 10, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 17,
-                                            19, 16, 21, 22, 20, 23,
+        static const uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                            6, 4, 5, 7,
+                                            11, 9, 8, 10,
+                                            14, 12, 13, 15,
+                                            19, 17, 16, 18,
+                                            22, 20, 21, 23,
                                             3, 2, 1, 0 };
 
         static const uint32_t s_preps[] = { 0, 1, 2, 3, 4, 5,
-                                            6, 7, 3, 6, 2, 7,
-                                            4, 1, 5, 0, 1, 4,
-                                            3, 6, 5, 0, 7, 2,
-                                            2, 0, 1, 3 };
+                                            6, 7, 0, 5, 7, 2,
+                                            1, 4, 6, 3, 2, 6,
+                                            5, 1, 3, 7, 4, 0,
+                                            0, 3, 1, 2 };
 
         std::vector<uint32_t> dups;
         dups.reserve( 4 );
@@ -2793,17 +2797,19 @@ bool Test20()
                                             22, 20, 21, 23,
                                             27, 26, uint32_t(-1), 24 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 0, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 0,
-                                            19, 16, 21, 22, 20, 23,
-                                            3, 0, 1, 0 };
+        static const uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                            6, 4, 5, 7,
+                                            11, 9, 0, 10,
+                                            14, 12, 13, 15,
+                                            19, 0, 16, 18,
+                                            22, 20, 21, 23,
+                                            3, 2, 0, 0 };
 
         static const uint32_t s_preps[] = { 0, 1, 2, 3, 4, 5,
-                                            6, 7, uint32_t(-1), 6, 2, 7,
-                                            4, 1, 5, 0, 1, uint32_t(-1),
-                                            3, 6, 5, 0, 7, 2,
-                                            2, uint32_t(-1), 1, 3 };
+                                            6, 7, 0, 5, uint32_t(-1), 2,
+                                            1, 4, 6, 3, 2, uint32_t(-1),
+                                            5, 1, 3, 7, 4, 0,
+                                            0, 3, uint32_t(-1), 2 };
 
         std::vector<uint32_t> dups;
         dups.reserve( 4 );

--- a/mesh/adjacency.cpp
+++ b/mesh/adjacency.cpp
@@ -2507,11 +2507,6 @@ bool Test19()
                                             19, 17, 16, 18,
                                             22, 20, 21, 23 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 10, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 17,
-                                            19, 16, 21, 22, 20, 23 };
-
         static const uint32_t s_preps[] = { 0, 1, 2, 3, 4, 5,
                                             6, 7, 3, 6, 2, 7,
                                             4, 1, 5, 0, 1, 4,
@@ -2523,13 +2518,13 @@ bool Test19()
             printe("ERROR: FinalizeVBAndPointReps fmcube failed (%08X)\n", hr );
             success = false;
         }
-        else if ( memcmp( destvb.get(), s_sorted, sizeof(s_sorted) ) != 0 )
+        else if ( memcmp( destvb.get(), s_remap, sizeof(s_remap) ) != 0 )
         {
             printe("ERROR: FinalizeVBAndPointReps fmcube vb failed\n" );
             success = false;
             for( size_t j = 0; j < 24; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_remap[ j ] );
             }
         }
         else if ( memcmp( prout.get(), s_preps, sizeof(s_preps) ) != 0 )
@@ -2556,13 +2551,13 @@ bool Test19()
             printe("ERROR: FinalizeVBAndPointReps fmcube [in-place] failed (%08X)\n", hr );
             success = false;
         }
-        else if ( memcmp( srcvb.get(), s_sorted, sizeof(s_sorted) ) != 0 )
+        else if ( memcmp( srcvb.get(), s_remap, sizeof(s_remap) ) != 0 )
         {
             printe("ERROR: FinalizeVBAndPointReps fmcube [in-place] vb failed\n" );
             success = false;
             for( size_t j = 0; j < 24; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, srcvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, srcvb[ j ], s_remap[ j ] );
             }
         }        
         else if ( memcmp( prout.get(), s_preps, sizeof(s_preps) ) != 0 )

--- a/mesh/directxtest.cpp
+++ b/mesh/directxtest.cpp
@@ -97,6 +97,8 @@ bool RunTests()
             ++nFail;
             print("FAIL\n");
         }
+
+        _CrtDumpMemoryLeaks();
     }
 
     print("Ran %d tests, %d pass, %d fail\n", nPass+nFail, nPass, nFail);

--- a/mesh/remap.cpp
+++ b/mesh/remap.cpp
@@ -145,6 +145,12 @@ bool Test03()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
+        for (uint32_t j = 0; j < remap.size(); ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         auto destib = CreateIndexBuffer<uint16_t>( 1023, IB_ZERO );
 
         HRESULT hr = FinalizeIB( srcib.get(), 341, remap.data(), 1024, destib.get() );
@@ -154,10 +160,10 @@ bool Test03()
             success = false;
         }
         else
-        {	
+        {
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( destib[ j ] != remap[ srcib[ j ] ] )
+                if ( destib[ j ] != inverseRemap[ srcib[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(16) shuffle failed\n" );
                     success = false;
@@ -178,7 +184,7 @@ bool Test03()
         {
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( srcib[ j ] != remap[ srcib2[ j ] ] )
+                if ( srcib[ j ] != inverseRemap[ srcib2[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(16) shuffle [in-place] failed\n" );
                     success = false;
@@ -204,18 +210,18 @@ bool Test03()
 
         static const uint16_t s_sorted[] =
         {
-            2, 1, 3,
             0, 1, 2,
-            5, 6, 4,
-            7, 6, 5,
-            10, 9, 11,
+            3, 1, 0,
+            4, 5, 6,
+            7, 5, 4,
             8, 9, 10,
-            13, 14, 12,
-            15, 14, 13,
-            18, 17, 19,
+            11, 9, 8,
+            12, 13, 14,
+            15, 13, 12,
             16, 17, 18,
-            21, 22, 20,
-            23, 22, 21
+            19, 17, 16,
+            20, 21, 22,
+            23, 21, 20,
         };
 
         HRESULT hr = FinalizeIB( g_fmCubeIndices16, 12, s_remap, 24, destib.get() );
@@ -396,6 +402,12 @@ bool Test03()
         for( uint32_t j = 0; j < 1024; ++j )
             remap[j] = 1023 - j;
 
+        uint32_t inverseRemap[1024];
+        for (uint32_t j = 0; j < 1024; ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         auto destib = CreateIndexBuffer<uint32_t>( 1023, IB_ZERO );
 
         HRESULT hr = FinalizeIB( srcib.get(), 341, remap, 1024, destib.get() );
@@ -408,7 +420,7 @@ bool Test03()
         {	
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( destib[ j ] != remap[ srcib[ j ] ] )
+                if ( destib[ j ] != inverseRemap[ srcib[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(32) reverse failed\n" );
                     success = false;
@@ -429,7 +441,7 @@ bool Test03()
         {
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( srcib[ j ] != remap[ srcib2[ j ] ] )
+                if ( srcib[ j ] != inverseRemap[ srcib2[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(32) reverse [in-place] failed\n" );
                     success = false;
@@ -451,6 +463,12 @@ bool Test03()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
+        for (uint32_t j = 0; j < remap.size(); ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         auto destib = CreateIndexBuffer<uint32_t>( 1023, IB_ZERO );
 
         HRESULT hr = FinalizeIB( srcib.get(), 341, remap.data(), 1024, destib.get() );
@@ -463,7 +481,7 @@ bool Test03()
         {	
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( destib[ j ] != remap[ srcib[ j ] ] )
+                if ( destib[ j ] != inverseRemap[ srcib[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(32) shuffle failed\n" );
                     success = false;
@@ -484,7 +502,7 @@ bool Test03()
         {
             for( size_t j = 0; j < 1023; ++j )
             {
-                if ( srcib[ j ] != remap[ srcib2[ j ] ] )
+                if ( srcib[ j ] != inverseRemap[ srcib2[ j ] ] )
                 {
                     printe("ERROR: FinalizeIB(32) shuffle [in-place] failed\n" );
                     success = false;
@@ -510,18 +528,18 @@ bool Test03()
 
         static const uint32_t s_sorted[] =
         {
-            2, 1, 3,
             0, 1, 2,
-            5, 6, 4,
-            7, 6, 5,
-            10, 9, 11,
+            3, 1, 0,
+            4, 5, 6,
+            7, 5, 4,
             8, 9, 10,
-            13, 14, 12,
-            15, 14, 13,
-            18, 17, 19,
+            11, 9, 8,
+            12, 13, 14,
+            15, 13, 12,
             16, 17, 18,
-            21, 22, 20,
-            23, 22, 21
+            19, 17, 16,
+            20, 21, 22,
+            23, 21, 20,
         };
 
         HRESULT hr = FinalizeIB( g_fmCubeIndices32, 12, s_remap, 24, destib.get() );
@@ -681,18 +699,18 @@ bool Test03()
 
         static const uint16_t s_sorted[] =
         {
-            2, 1, 3,
             0, 1, 2,
-            5, 6, 4,
-            7, 6, 5,
-            10, 9, 11,
+            3, 1, 0,
+            4, 5, 6,
+            7, 5, 4,
+            8, 9, 10,
             uint16_t(-1), uint16_t(-1), uint16_t(-1),
-            14, 14, 12,
-            15, 14, 14,
-            18, 17, 19,
+            12, 13, 13,
+            15, 13, 12,
             16, 17, 18,
-            21, 22, 20,
-            23, 22, 21
+            19, 17, 16,
+            20, 21, 22,
+            23, 21, 20,
         };
 
         HRESULT hr = FinalizeIB( s_unused, 12, s_remap, 24, destib.get() );
@@ -776,18 +794,18 @@ bool Test03()
 
         static const uint32_t s_sorted[] =
         {
-            2, 1, 3,
             0, 1, 2,
-            5, 6, 4,
-            7, 6, 5,
-            10, 9, 11,
+            3, 1, 0,
+            4, 5, 6,
+            7, 5, 4,
+            8, 9, 10,
             uint32_t(-1), uint32_t(-1), uint32_t(-1),
-            14, 14, 12,
-            15, 14, 14,
-            18, 17, 19,
+            12, 13, 13,
+            15, 13, 12,
             16, 17, 18,
-            21, 22, 20,
-            23, 22, 21
+            19, 17, 16,
+            20, 21, 22,
+            23, 21, 20,
         };
 
         HRESULT hr = FinalizeIB( s_unused, 12, s_remap, 24, destib.get() );
@@ -947,6 +965,12 @@ bool Test04()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
+        for (uint32_t j = 0; j < remap.size(); ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         auto destvb = CreateVertexBuffer( 32, 65535 );
 
         HRESULT hr = FinalizeVB( srcvb.get(), 32, 65535, nullptr, 0, remap.data(), destvb.get() );
@@ -960,7 +984,7 @@ bool Test04()
         {
             for( size_t j = 0; j < 65535; ++j )
             {
-                auto ptr = destvb.get() + 32*remap[j];
+                auto ptr = destvb.get() + 32* inverseRemap[j];
                 if ( !IsTestVBCorrect32( ptr, DWORD( j ) ) )
                 {
                     printe("ERROR: FinalizeVB(32) shuffle failed\n" );
@@ -982,7 +1006,7 @@ bool Test04()
         {
             for( size_t j = 0; j < 65535; ++j )
             {
-                auto ptr = srcvb.get() + 32*remap[j];
+                auto ptr = srcvb.get() + 32* inverseRemap[j];
                 if ( !IsTestVBCorrect32( ptr, DWORD( j ) ) )
                 {
                     printe("ERROR: FinalizeVB(32) shuffle [in-place] failed\n" );
@@ -1106,6 +1130,12 @@ bool Test04()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
+        for (uint32_t j = 0; j < remap.size(); ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         auto destvb = CreateVertexBuffer( 16, 65535 );
 
         HRESULT hr = FinalizeVB( srcvb.get(), 16, 65535, nullptr, 0, remap.data(), destvb.get() );
@@ -1119,7 +1149,7 @@ bool Test04()
         {
             for( size_t j = 0; j < 65535; ++j )
             {
-                auto ptr = destvb.get() + 16*remap[j];
+                auto ptr = destvb.get() + 16* inverseRemap[j];
                 if ( !IsTestVBCorrect16( ptr, DWORD(j) ) )
                 {
                     printe("ERROR: FinalizeVB(16) shuffle failed\n" );
@@ -1141,7 +1171,7 @@ bool Test04()
         {
             for( size_t j = 0; j < 65535; ++j )
             {
-                auto ptr = srcvb.get() + 16*remap[j];
+                auto ptr = srcvb.get() + 16* inverseRemap[j];
                 if ( !IsTestVBCorrect16( ptr, DWORD(j) ) )
                 {
                     printe("ERROR: FinalizeVB(16) shuffle [in-place] failed\n" );
@@ -1171,24 +1201,19 @@ bool Test04()
                                             19, 17, 16, 18,
                                             22, 20, 21, 23 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 10, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 17,
-                                            19, 16, 21, 22, 20, 23 };
-
         HRESULT hr = FinalizeVB( srcvb.get(), sizeof(uint32_t), 24, nullptr, 0, s_remap, destvb.get() );
         if ( FAILED(hr) )
         {
             printe("ERROR: FinalizeVB fmcube failed (%08X)\n", hr );
             success = false;
         }
-        else if ( memcmp( destvb.get(), s_sorted, sizeof(s_sorted) ) != 0 )
+        else if ( memcmp( destvb.get(), s_remap, sizeof(s_remap) ) != 0 )
         {
             printe("ERROR: FinalizeVB fmcube failed\n" );
             success = false;
             for( size_t j = 0; j < 24; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_remap[ j ] );
             }
         }
 
@@ -1202,13 +1227,13 @@ bool Test04()
             printe("ERROR: FinalizeVB fmcube [in-place] failed (%08X)\n", hr );
             success = false;
         }
-        else if ( memcmp( srcvb.get(), s_sorted, sizeof(s_sorted) ) != 0 )
+        else if ( memcmp( srcvb.get(), s_remap, sizeof(s_remap) ) != 0 )
         {
             printe("ERROR: FinalizeVB fmcube [in-place] failed\n" );
             success = false;
             for( size_t j = 0; j < 24; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, srcvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, srcvb[ j ], s_remap[ j ] );
             }
         }        
 
@@ -1285,7 +1310,7 @@ bool Test04()
             srcvb[ j ] = j;
 
         std::unique_ptr<uint32_t[]> destvb( new uint32_t[ 24 ] );
-        memset( destvb.get(), 0, sizeof(uint32_t) * 24 );
+        memset( destvb.get(), 0xff, sizeof(uint32_t) * 24 );
 
         const static uint32_t s_remap[] = { 3, 1, 0, 2,
                                             6, 4, 5, 7,
@@ -1294,10 +1319,12 @@ bool Test04()
                                             19, uint32_t(-1), 16, 18,
                                             22, 20, 21, 23 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 0, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 0,
-                                            19, 16, 21, 22, 20, 23 };
+        const static uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                            6, 4, 5, 7,
+                                            11, 9, 0, 10,
+                                            14, 12, 13, 15,
+                                            19, 0, 16, 18,
+                                            22, 20, 21, 23 };
 
         HRESULT hr = FinalizeVB( srcvb.get(), sizeof(uint32_t), 24, nullptr, 0, s_remap, destvb.get() );
         if ( FAILED(hr) )
@@ -1311,7 +1338,7 @@ bool Test04()
             success = false;
             for( size_t j = 0; j < 24; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );
             }
         }
     }
@@ -1471,6 +1498,12 @@ bool Test05()
  
         std::random_shuffle( remap.begin(), remap.end() );
 
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
+        for (uint32_t j = 0; j < remap.size(); ++j)
+        {
+            inverseRemap[remap[j]] = j;
+        }
+
         std::vector<uint32_t> dups;
         dups.reserve( 256 );
         for( uint32_t j = 0; j < 256; ++j )
@@ -1488,7 +1521,7 @@ bool Test05()
         {
             for( size_t j = 0; j < 65535; ++j )
             {
-                auto ptr = destvb.get() + 32*remap[j];
+                auto ptr = destvb.get() + 32* inverseRemap[j];
                 if ( !IsTestVBCorrect32( ptr, DWORD(j) ) )
                 {
                     printe("ERROR: FinalizeVB(32) dups shuffle [remap] failed\n" );
@@ -1500,7 +1533,7 @@ bool Test05()
 
             for( size_t j = 65536; j < (65535 + 256); ++j )
             {
-                auto ptr = destvb.get() + 32*remap[j];
+                auto ptr = destvb.get() + 32* inverseRemap[j];
                 if ( !IsTestVBCorrect32( ptr, DWORD( j - 65535 ) ) )
                 {
                     printe("ERROR: FinalizeVB(32) dups shuffle [remap] failed (2)\n" );
@@ -1536,11 +1569,13 @@ bool Test05()
                                             22, 20, 21, 23,
                                             27, 26, 25, 24 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 10, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 17,
-                                            19, 16, 21, 22, 20, 23,
-                                             3, 2, 1, 0 };
+        const static uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                            6, 4, 5, 7,
+                                            11, 9, 8, 10,
+                                            14, 12, 13, 15,
+                                            19, 17, 16, 18,
+                                            22, 20, 21, 23,
+                                             3,  2,  1,  0 };
 
         HRESULT hr = FinalizeVB( srcvb.get(), sizeof(uint32_t), 24, dups.data(), dups.size(), s_remap, destvb.get() );
         if ( FAILED(hr) )
@@ -1554,7 +1589,7 @@ bool Test05()
             success = false;
             for( size_t j = 0; j < 28; ++j )
             {
-                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );  
+                printe("\t%Iu: %u .. %u\n", j, destvb[ j ], s_sorted[ j ] );
             }
         }
     }
@@ -1583,11 +1618,13 @@ bool Test05()
                                             22, 20, 21, 23,
                                             27, 26, uint32_t(-1), 24 };
 
-        static const uint32_t s_sorted[] = { 2, 1, 3, 0, 5, 6,
-                                             4, 7, 0, 9, 11, 8,
-                                            13, 14, 12, 15, 18, 0,
-                                            19, 16, 21, 22, 20, 23,
-                                            3, 0, 1, 0 };
+        const static uint32_t s_sorted[] = { 3, 1, 0, 2,
+                                             6, 4, 5, 7,
+                                             11, 9, 0, 10,
+                                             14, 12, 13, 15,
+                                             19, 0, 16, 18,
+                                             22, 20, 21, 23,
+                                             3,  2,  0,  0 };
 
         HRESULT hr = FinalizeVB( srcvb.get(), sizeof(uint32_t), 24, dups.data(), dups.size(), s_remap, destvb.get() );
         if ( FAILED(hr) )

--- a/mesh/remap.cpp
+++ b/mesh/remap.cpp
@@ -145,8 +145,8 @@ bool Test03()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
-        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
-        for (uint32_t j = 0; j < remap.size(); ++j)
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[1024]);
+        for (uint32_t j = 0; j < 1024; ++j)
         {
             inverseRemap[remap[j]] = j;
         }
@@ -463,8 +463,8 @@ bool Test03()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
-        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
-        for (uint32_t j = 0; j < remap.size(); ++j)
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[1024]);
+        for (uint32_t j = 0; j < 1024; ++j)
         {
             inverseRemap[remap[j]] = j;
         }
@@ -965,8 +965,8 @@ bool Test04()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
-        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
-        for (uint32_t j = 0; j < remap.size(); ++j)
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[65535]);
+        for (uint32_t j = 0; j < 65535; ++j)
         {
             inverseRemap[remap[j]] = j;
         }
@@ -1130,8 +1130,8 @@ bool Test04()
 
         std::random_shuffle( remap.begin(), remap.end() );
 
-        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
-        for (uint32_t j = 0; j < remap.size(); ++j)
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[65535]);
+        for (uint32_t j = 0; j < 65535; ++j)
         {
             inverseRemap[remap[j]] = j;
         }
@@ -1310,7 +1310,7 @@ bool Test04()
             srcvb[ j ] = j;
 
         std::unique_ptr<uint32_t[]> destvb( new uint32_t[ 24 ] );
-        memset( destvb.get(), 0xff, sizeof(uint32_t) * 24 );
+        memset( destvb.get(), 0, sizeof(uint32_t) * 24 );
 
         const static uint32_t s_remap[] = { 3, 1, 0, 2,
                                             6, 4, 5, 7,
@@ -1498,8 +1498,8 @@ bool Test05()
  
         std::random_shuffle( remap.begin(), remap.end() );
 
-        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[remap.size()]);
-        for (uint32_t j = 0; j < remap.size(); ++j)
+        std::unique_ptr<uint32_t[]> inverseRemap(new uint32_t[65535 + 256]);
+        for (uint32_t j = 0; j < (65535 + 256); ++j)
         {
             inverseRemap[remap[j]] = j;
         }


### PR DESCRIPTION
``OptimizeVertices`` returns a vertexRemap array that matches the D3DX public API, namely: ``oldLoc = vertexRemap[newLoc]``. This is consistent with OptimizeFaces faceRemap.

Unfortunately, the remap functions interpreted the vertexRemap incorrectly as: ``newLoc = vertexRemap[oldLoc]``.

This error became obvious when doing better vertex texture fetch analysis and the ``WeldVertices`` operation.

This change fixes the remap functions.