### PR TITLE
Windows 10 April 2018 Update SDK (17134)

### DIFF
--- a/cp/xtcp_Desktop_2017.vcxproj
+++ b/cp/xtcp_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{811DBC21-0BA0-44E6-8F08-9B8A4E96E058}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtcp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/cp/xtcp_Desktop_2017_Win10.vcxproj
+++ b/cp/xtcp_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{811DBC21-0BA0-44E6-8F08-9B8A4E96E058}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtcp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/mesh/xtmesh_Desktop_2017.vcxproj
+++ b/mesh/xtmesh_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{475EEB5A-3133-437F-99CC-F26B41285A54}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtmesh</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/mesh/xtmesh_Desktop_2017_Win10.vcxproj
+++ b/mesh/xtmesh_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{475EEB5A-3133-437F-99CC-F26B41285A54}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtmesh</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/vb/xtvb_Desktop_2017.vcxproj
+++ b/vb/xtvb_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{53ACCB10-4A85-4845-8367-2E8C7891A475}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtvb</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/vb/xtvb_Desktop_2017_Win10.vcxproj
+++ b/vb/xtvb_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{53ACCB10-4A85-4845-8367-2E8C7891A475}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtvb</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Updated VS 2017 projects to use the Windows 10 SDK (17134) which requires the VS 2017 (15.7 update)